### PR TITLE
Ensure commands always have descriptions.

### DIFF
--- a/src/Mongrate/MongrateBundle/Tests/Command/AbstractCommandTest.php
+++ b/src/Mongrate/MongrateBundle/Tests/Command/AbstractCommandTest.php
@@ -25,5 +25,6 @@ abstract class AbstractCommandTest extends \PHPUnit_Framework_TestCase
     {
         $command = $this->application->find($name);
         $this->assertEquals($name, $command->getName());
+        $this->assertNotEmpty($command->getDescription());
     }
 }


### PR DESCRIPTION
Issues #7 and #8 say that the 'mongrate:up/down' commands
have no description. They have descriptions now, so this
test isn't really needed, but it's a fallback check to
make sure every command has a description.
