### PR TITLE
Ensure bundle commands are registered in the bundle.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,11 @@ env:
   - PREFER_LOWEST=""
 
 php:
-    - 5.4
+    # Although the bundle's implementation code works with PHP 5.4, the tests use `::class`
+    # which is only available since 5.5. 5.4 has reached it's end of life, so we won't bother
+    # with actively testing the implementation code against it.
     - 5.5
+    - 5.6
 
 services:
     - mongodb

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,9 @@
     },
     "minimum-stability": "stable",
     "require-dev": {
+        "symfony/http-kernel": ">=2.3.0",
+        "symfony/dependency-injection": ">=2.3.0",
+        "symfony/framework-bundle": ">=2.3.0",
         "phpunit/phpunit": "^4.6"
     }
 }

--- a/src/Mongrate/MongrateBundle/Tests/Command/AbstractCommandTest.php
+++ b/src/Mongrate/MongrateBundle/Tests/Command/AbstractCommandTest.php
@@ -21,10 +21,11 @@ abstract class AbstractCommandTest extends \PHPUnit_Framework_TestCase
         ];
     }
 
-    protected function assertCommandIsFound($name)
+    protected function assertCommandIsFound($name, $class)
     {
         $command = $this->application->find($name);
         $this->assertEquals($name, $command->getName());
         $this->assertNotEmpty($command->getDescription());
+        $this->assertInstanceOf($class, $command);
     }
 }

--- a/src/Mongrate/MongrateBundle/Tests/Command/DownCommandTest.php
+++ b/src/Mongrate/MongrateBundle/Tests/Command/DownCommandTest.php
@@ -12,6 +12,6 @@ class DownCommandTest extends AbstractCommandTest
     {
         $this->application->add(new DownCommand($this->config));
 
-        $this->assertCommandIsFound('mongrate:down');
+        $this->assertCommandIsFound('mongrate:down', DownCommand::class);
     }
 }

--- a/src/Mongrate/MongrateBundle/Tests/Command/GenerateMigrationCommandTest.php
+++ b/src/Mongrate/MongrateBundle/Tests/Command/GenerateMigrationCommandTest.php
@@ -12,6 +12,6 @@ class GenerateMigrationCommandTest extends AbstractCommandTest
     {
         $this->application->add(new GenerateMigrationCommand($this->config));
 
-        $this->assertCommandIsFound('mongrate:generate-migration');
+        $this->assertCommandIsFound('mongrate:generate-migration', GenerateMigrationCommand::class);
     }
 }

--- a/src/Mongrate/MongrateBundle/Tests/Command/ListCommandTest.php
+++ b/src/Mongrate/MongrateBundle/Tests/Command/ListCommandTest.php
@@ -12,6 +12,6 @@ class ListCommandTest extends AbstractCommandTest
     {
         $this->application->add(new ListCommand($this->config));
 
-        $this->assertCommandIsFound('mongrate:list-migrations');
+        $this->assertCommandIsFound('mongrate:list-migrations', ListCommand::class);
     }
 }

--- a/src/Mongrate/MongrateBundle/Tests/Command/TestCommandTest.php
+++ b/src/Mongrate/MongrateBundle/Tests/Command/TestCommandTest.php
@@ -12,7 +12,7 @@ class TestCommandTest extends AbstractCommandTest
     {
         $this->application->add(new TestCommand($this->config));
 
-        $this->assertCommandIsFound('mongrate:test');
+        $this->assertCommandIsFound('mongrate:test', TestCommand::class);
     }
 
 }

--- a/src/Mongrate/MongrateBundle/Tests/Command/ToggleMigrationCommandTest.php
+++ b/src/Mongrate/MongrateBundle/Tests/Command/ToggleMigrationCommandTest.php
@@ -12,6 +12,6 @@ class ToggleMigrationCommandTest extends AbstractCommandTest
     {
         $this->application->add(new ToggleMigrationCommand($this->config));
 
-        $this->assertCommandIsFound('mongrate:toggle');
+        $this->assertCommandIsFound('mongrate:toggle', ToggleMigrationCommand::class);
     }
 }

--- a/src/Mongrate/MongrateBundle/Tests/Command/UpAllCommandTest.php
+++ b/src/Mongrate/MongrateBundle/Tests/Command/UpAllCommandTest.php
@@ -12,6 +12,6 @@ class UpAllCommandTest extends AbstractCommandTest
     {
         $this->application->add(new UpAllCommand($this->config));
 
-        $this->assertCommandIsFound('mongrate:up-all');
+        $this->assertCommandIsFound('mongrate:up-all', UpAllCommand::class);
     }
 }

--- a/src/Mongrate/MongrateBundle/Tests/Command/UpCommandTest.php
+++ b/src/Mongrate/MongrateBundle/Tests/Command/UpCommandTest.php
@@ -12,6 +12,6 @@ class UpCommandTest extends AbstractCommandTest
     {
         $this->application->add(new UpCommand($this->config));
 
-        $this->assertCommandIsFound('mongrate:up');
+        $this->assertCommandIsFound('mongrate:up', UpCommand::class);
     }
 }


### PR DESCRIPTION
This will prevent mistakes like creating the command but forgetting to register it (e.g. see #20 )
