### PR TITLE
ContainerAwareMigrationService

### DIFF
--- a/src/Mongrate/MongrateBundle/Command/DownCommand.php
+++ b/src/Mongrate/MongrateBundle/Command/DownCommand.php
@@ -2,12 +2,41 @@
 
 namespace Mongrate\MongrateBundle\Command;
 
-class DownCommand extends \Mongrate\Command\DownCommand
+use Mongrate\Configuration;
+use Mongrate\MongrateBundle\Service\ContainerAwareMigrationService;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+
+class DownCommand extends \Mongrate\Command\DownCommand implements ContainerAwareInterface
 {
     use ExtendsStandaloneMongrateCommandTrait;
+    use ContainerAwareTrait;
+
+    /**
+     * @var ContainerAwareMigrationService
+     */
+    protected $service;
 
     public function __construct(array $config)
     {
         parent::__construct(null, $config);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function getMigrationService(Configuration $configuration)
+    {
+        return new ContainerAwareMigrationService($configuration);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function initialize(InputInterface $input, OutputInterface $output)
+    {
+        $this->service->setContainer($this->container);
     }
 }

--- a/src/Mongrate/MongrateBundle/Command/TestCommand.php
+++ b/src/Mongrate/MongrateBundle/Command/TestCommand.php
@@ -2,12 +2,41 @@
 
 namespace Mongrate\MongrateBundle\Command;
 
-class TestCommand extends \Mongrate\Command\TestMigrationCommand
+use Mongrate\Configuration;
+use Mongrate\MongrateBundle\Service\ContainerAwareMigrationService;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+
+class TestCommand extends \Mongrate\Command\TestMigrationCommand implements ContainerAwareInterface
 {
     use ExtendsStandaloneMongrateCommandTrait;
+    use ContainerAwareTrait;
 
+    /**
+     * @var ContainerAwareMigrationService
+     */
+    protected $service;
+    
     public function __construct(array $config)
     {
         parent::__construct(null, $config);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function getMigrationService(Configuration $configuration)
+    {
+        return new ContainerAwareMigrationService($configuration);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function initialize(InputInterface $input, OutputInterface $output)
+    {
+        $this->service->setContainer($this->container);
     }
 }

--- a/src/Mongrate/MongrateBundle/Command/ToggleMigrationCommand.php
+++ b/src/Mongrate/MongrateBundle/Command/ToggleMigrationCommand.php
@@ -2,12 +2,41 @@
 
 namespace Mongrate\MongrateBundle\Command;
 
-class ToggleMigrationCommand extends \Mongrate\Command\ToggleMigrationCommand
+use Mongrate\Configuration;
+use Mongrate\MongrateBundle\Service\ContainerAwareMigrationService;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+
+class ToggleMigrationCommand extends \Mongrate\Command\ToggleMigrationCommand implements ContainerAwareInterface
 {
     use ExtendsStandaloneMongrateCommandTrait;
+    use ContainerAwareTrait;
+    
+    /**
+     * @var ContainerAwareMigrationService
+     */
+    protected $service;
 
     public function __construct(array $config)
     {
         parent::__construct(null, $config);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function getMigrationService(Configuration $configuration)
+    {
+        return new ContainerAwareMigrationService($configuration);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function initialize(InputInterface $input, OutputInterface $output)
+    {
+        $this->service->setContainer($this->container);
     }
 }

--- a/src/Mongrate/MongrateBundle/Command/UpAllCommand.php
+++ b/src/Mongrate/MongrateBundle/Command/UpAllCommand.php
@@ -2,12 +2,41 @@
 
 namespace Mongrate\MongrateBundle\Command;
 
-class UpAllCommand extends \Mongrate\Command\UpAllCommand
+use Mongrate\Configuration;
+use Mongrate\MongrateBundle\Service\ContainerAwareMigrationService;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+
+class UpAllCommand extends \Mongrate\Command\UpAllCommand implements ContainerAwareInterface
 {
     use ExtendsStandaloneMongrateCommandTrait;
+    use ContainerAwareTrait;
+    
+    /**
+     * @var ContainerAwareMigrationService
+     */
+    protected $service;
 
     public function __construct(array $config)
     {
         parent::__construct(null, $config);
+    }
+    
+    /**
+     * @inheritdoc
+     */
+    protected function getMigrationService(Configuration $configuration)
+    {
+        return new ContainerAwareMigrationService($configuration);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function initialize(InputInterface $input, OutputInterface $output)
+    {
+        $this->service->setContainer($this->container);
     }
 }

--- a/src/Mongrate/MongrateBundle/Command/UpCommand.php
+++ b/src/Mongrate/MongrateBundle/Command/UpCommand.php
@@ -2,12 +2,41 @@
 
 namespace Mongrate\MongrateBundle\Command;
 
-class UpCommand extends \Mongrate\Command\UpCommand
+use Mongrate\Configuration;
+use Mongrate\MongrateBundle\Service\ContainerAwareMigrationService;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+
+class UpCommand extends \Mongrate\Command\UpCommand implements ContainerAwareInterface
 {
     use ExtendsStandaloneMongrateCommandTrait;
+    use ContainerAwareTrait;
+
+    /**
+     * @var ContainerAwareMigrationService
+     */
+    protected $service;
 
     public function __construct(array $config)
     {
         parent::__construct(null, $config);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function getMigrationService(Configuration $configuration)
+    {
+        return new ContainerAwareMigrationService($configuration);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function initialize(InputInterface $input, OutputInterface $output)
+    {
+        $this->service->setContainer($this->container);
     }
 }

--- a/src/Mongrate/MongrateBundle/Service/ContainerAwareMigrationService.php
+++ b/src/Mongrate/MongrateBundle/Service/ContainerAwareMigrationService.php
@@ -2,36 +2,27 @@
 
 namespace Mongrate\MongrateBundle\Service;
 
+use Mongrate\Model\Name;
+use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Mongrate\Service\MigrationService;
 
 class ContainerAwareMigrationService extends MigrationService implements ContainerAwareInterface
 {
-    /**
-     * @var ContainerInterface $container
-     */
-    private $container;
- 
-    /**
-     * @param ContainerInterface $container
-     */
-    public function setContainer(ContainerInterface $container = null)
-    {
-        $this->container = $container;
-    }
+    use ContainerAwareTrait;
     
     /**
      * @inheritdoc
      */
     public function createMigrationInstance(Name $name, OutputInterface $output)
     {
-        $migration = parent::createMigrationInstance(Name $name, OutputInterface $output);
-        
+        $migration = parent::createMigrationInstance($name, $output);
+
         if ($migration instanceof ContainerAwareInterface) {
             $migration->setContainer($this->container);
         }
-        
+
         return $migration;
     }
 }

--- a/src/Mongrate/MongrateBundle/Service/ContainerAwareMigrationService.php
+++ b/src/Mongrate/MongrateBundle/Service/ContainerAwareMigrationService.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Mongrate\MongrateBundle\Service;
+
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Mongrate\Service\MigrationService;
+
+class ContainerAwareMigrationService extends MigrationService implements ContainerAwareInterface
+{
+    /**
+     * @var ContainerInterface $container
+     */
+    private $container;
+ 
+    /**
+     * @param ContainerInterface $container
+     */
+    public function setContainer(ContainerInterface $container = null)
+    {
+        $this->container = $container;
+    }
+    
+    /**
+     * @inheritdoc
+     */
+    public function createMigrationInstance(Name $name, OutputInterface $output)
+    {
+        $migration = parent::createMigrationInstance(Name $name, OutputInterface $output);
+        
+        if ($migration instanceof ContainerAwareInterface) {
+            $migration->setContainer($this->container);
+        }
+        
+        return $migration;
+    }
+}

--- a/src/Mongrate/MongrateBundle/Tests/Command/AbstractCommandTest.php
+++ b/src/Mongrate/MongrateBundle/Tests/Command/AbstractCommandTest.php
@@ -6,6 +6,11 @@ use Mongrate\MongrateBundle\MongrateBundle;
 use Mongrate\MongrateBundle\Tests\TestKernel;
 use Symfony\Component\Console\Application;
 use Symfony\Bundle\FrameworkBundle\Console\Application as FrameworkApplication;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 abstract class AbstractCommandTest extends \PHPUnit_Framework_TestCase
 {
@@ -19,7 +24,7 @@ abstract class AbstractCommandTest extends \PHPUnit_Framework_TestCase
 
         $this->config = [
             'migrations_directory' => '/',
-            'mongodb_server' => 'localhost',
+            'mongodb_server' => 'mongo',
             'mongodb_db' => 'test'
         ];
     }
@@ -52,5 +57,31 @@ abstract class AbstractCommandTest extends \PHPUnit_Framework_TestCase
         $bundle->registerCommands($frameworkApplication);
 
         $this->assertInstanceOf($class, $frameworkApplication->find($name));
+    }
+
+    public function assertIsContainerAware($name, $class)
+    {
+        self::assertInstanceOf(
+            ContainerAwareInterface::class,
+            new $class($this->config),
+            sprintf('The %s command is not instance of ContainerAwareInterface', $name)
+        );
+    }
+    
+    public function assertContainerWasInjectedToService($name, $class)
+    {
+        $this->application->add(new $class($this->config));
+
+        $command = $this->application->get($name);
+
+        $command->setContainer(new Container());
+        $command->initialize(New ArrayInput([]), new NullOutput());
+
+        self::assertAttributeInstanceOf(
+            ContainerInterface::class,
+            'container',
+            \PHPUnit_Framework_Assert::getObjectAttribute($command, 'service'),
+            sprintf('Container wasn\'t injected to the MigrationService by %s command', $name)
+        );
     }
 }

--- a/src/Mongrate/MongrateBundle/Tests/Command/AbstractCommandTest.php
+++ b/src/Mongrate/MongrateBundle/Tests/Command/AbstractCommandTest.php
@@ -24,7 +24,7 @@ abstract class AbstractCommandTest extends \PHPUnit_Framework_TestCase
 
         $this->config = [
             'migrations_directory' => '/',
-            'mongodb_server' => 'mongo',
+            'mongodb_server' => 'localhost',
             'mongodb_db' => 'test'
         ];
     }

--- a/src/Mongrate/MongrateBundle/Tests/Command/DownCommandTest.php
+++ b/src/Mongrate/MongrateBundle/Tests/Command/DownCommandTest.php
@@ -5,6 +5,7 @@ namespace Mongrate\MongrateBundle\Tests\Command;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 use Mongrate\MongrateBundle\Command\DownCommand;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 
 class DownCommandTest extends AbstractCommandTest
 {
@@ -13,5 +14,15 @@ class DownCommandTest extends AbstractCommandTest
         $this->application->add(new DownCommand($this->config));
 
         $this->assertCommandIsFound('mongrate:down', DownCommand::class);
+    }
+
+    public function testIsContainerAware()
+    {
+        $this->assertIsContainerAware('mongrate:down', DownCommand::class);
+    }
+
+    public function testIsContainerWasInjectedToService()
+    {
+        $this->assertContainerWasInjectedToService('mongrate:down', DownCommand::class);
     }
 }

--- a/src/Mongrate/MongrateBundle/Tests/Command/TestCommandTest.php
+++ b/src/Mongrate/MongrateBundle/Tests/Command/TestCommandTest.php
@@ -5,6 +5,7 @@ namespace Mongrate\MongrateBundle\Tests\Command;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 use Mongrate\MongrateBundle\Command\TestCommand;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 
 class TestCommandTest extends AbstractCommandTest
 {
@@ -15,4 +16,13 @@ class TestCommandTest extends AbstractCommandTest
         $this->assertCommandIsFound('mongrate:test', TestCommand::class);
     }
 
+    public function testIsContainerAware()
+    {
+        $this->assertIsContainerAware('mongrate:test', TestCommand::class);
+    }
+
+    public function testIsContainerWasInjectedToService()
+    {
+        $this->assertContainerWasInjectedToService('mongrate:test', TestCommand::class);
+    }
 }

--- a/src/Mongrate/MongrateBundle/Tests/Command/ToggleMigrationCommandTest.php
+++ b/src/Mongrate/MongrateBundle/Tests/Command/ToggleMigrationCommandTest.php
@@ -5,6 +5,7 @@ namespace Mongrate\MongrateBundle\Tests\Command;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 use Mongrate\MongrateBundle\Command\ToggleMigrationCommand;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 
 class ToggleMigrationCommandTest extends AbstractCommandTest
 {
@@ -13,5 +14,15 @@ class ToggleMigrationCommandTest extends AbstractCommandTest
         $this->application->add(new ToggleMigrationCommand($this->config));
 
         $this->assertCommandIsFound('mongrate:toggle', ToggleMigrationCommand::class);
+    }
+    
+    public function testIsContainerAware()
+    {
+        $this->assertIsContainerAware('mongrate:toggle', ToggleMigrationCommand::class);
+    }
+
+    public function testIsContainerWasInjectedToService()
+    {
+        $this->assertContainerWasInjectedToService('mongrate:toggle', ToggleMigrationCommand::class);
     }
 }

--- a/src/Mongrate/MongrateBundle/Tests/Command/UpAllCommandTest.php
+++ b/src/Mongrate/MongrateBundle/Tests/Command/UpAllCommandTest.php
@@ -5,6 +5,7 @@ namespace Mongrate\MongrateBundle\Tests\Command;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 use Mongrate\MongrateBundle\Command\UpAllCommand;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 
 class UpAllCommandTest extends AbstractCommandTest
 {
@@ -13,5 +14,16 @@ class UpAllCommandTest extends AbstractCommandTest
         $this->application->add(new UpAllCommand($this->config));
 
         $this->assertCommandIsFound('mongrate:up-all', UpAllCommand::class);
+    }
+
+
+    public function testIsContainerAware()
+    {
+        $this->assertIsContainerAware('mongrate:up-all', UpAllCommand::class);
+    }
+
+    public function testIsContainerWasInjectedToService()
+    {
+        $this->assertContainerWasInjectedToService('mongrate:up-all', UpAllCommand::class);
     }
 }

--- a/src/Mongrate/MongrateBundle/Tests/Command/UpCommandTest.php
+++ b/src/Mongrate/MongrateBundle/Tests/Command/UpCommandTest.php
@@ -5,6 +5,7 @@ namespace Mongrate\MongrateBundle\Tests\Command;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 use Mongrate\MongrateBundle\Command\UpCommand;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 
 class UpCommandTest extends AbstractCommandTest
 {
@@ -13,5 +14,15 @@ class UpCommandTest extends AbstractCommandTest
         $this->application->add(new UpCommand($this->config));
 
         $this->assertCommandIsFound('mongrate:up', UpCommand::class);
+    }
+
+    public function testIsContainerAware()
+    {
+        $this->assertIsContainerAware('mongrate:up', UpCommand::class);
+    }
+
+    public function testIsContainerWasInjectedToService()
+    {
+        $this->assertContainerWasInjectedToService('mongrate:up', UpCommand::class);
     }
 }

--- a/src/Mongrate/MongrateBundle/Tests/Fixtures/ContainerAwareMigration/Migration.php
+++ b/src/Mongrate/MongrateBundle/Tests/Fixtures/ContainerAwareMigration/Migration.php
@@ -1,0 +1,13 @@
+<?php
+
+Namespace Mongrate\Migrations;
+
+use Mongrate\Migration\Migration;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+
+class ContainerAwareMigration implements ContainerAwareInterface
+{
+    use ContainerAwareTrait;
+    use Migration;
+}

--- a/src/Mongrate/MongrateBundle/Tests/Service/ContainerAwareMigrationServiceTest.php
+++ b/src/Mongrate/MongrateBundle/Tests/Service/ContainerAwareMigrationServiceTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Mongrate\MongrateBundle\Tests\Service;
+
+use Mongrate\Configuration;
+use Mongrate\Model\Migration;
+use Mongrate\Model\Name;
+use Mongrate\MongrateBundle\Service\ContainerAwareMigrationService;
+use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+class ContainerAwareMigrationServiceTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var ContainerAwareMigrationService
+     */
+    protected $service;
+
+    public function setUp()
+    {
+        $config = [
+            'migrations_directory' => 'src/Mongrate/MongrateBundle/Tests/Fixtures/',
+            'mongodb_server' => 'mongo',
+            'mongodb_db' => 'test'
+        ];
+
+        $this->service = new ContainerAwareMigrationService(new Configuration($config));
+        $this->service->setContainer(new Container());
+    }
+
+    public function testContainerInjectedToAwareMigration ()
+    {
+        $migration = $this->service->createMigrationInstance(
+            new Name('ContainerAwareMigration'),
+            new NullOutput()
+        );
+
+        self::assertAttributeInstanceOf(
+            ContainerInterface::class,
+            'container',
+            $migration,
+            'Container wasn\'t injected to a Migration by the Service'
+        );
+    }
+}

--- a/src/Mongrate/MongrateBundle/Tests/Service/ContainerAwareMigrationServiceTest.php
+++ b/src/Mongrate/MongrateBundle/Tests/Service/ContainerAwareMigrationServiceTest.php
@@ -21,7 +21,7 @@ class ContainerAwareMigrationServiceTest extends \PHPUnit_Framework_TestCase
     {
         $config = [
             'migrations_directory' => 'src/Mongrate/MongrateBundle/Tests/Fixtures/',
-            'mongodb_server' => 'mongo',
+            'mongodb_server' => 'localhost',
             'mongodb_db' => 'test'
         ];
 


### PR DESCRIPTION
Hi. 

It's not a real merge request yet, I only want to assure that this functionality is required in the project. In case of your interest I can add tests + docs + whatever.

Description: In some cases people may need an access to a symfony container during a migration. For this purpose we can mark a migration as a container-aware, and the service will inject Container into the migration.

[Original Idea](https://symfony.com/doc/current/bundles/DoctrineMigrationsBundle/index.html#container-aware-migrations)

Todo: 
- Real implementation
- Configurable class for symfony service
- Tests
- Docs 

To implement ContainerAware functionality in a migration I offer to use [ContainerAwareTrait](https://github.com/symfony/dependency-injection/blob/master/ContainerAwareTrait.php).
